### PR TITLE
Insert - Use Schema for Table Name

### DIFF
--- a/src/ClickhouseConnection.ts
+++ b/src/ClickhouseConnection.ts
@@ -52,8 +52,12 @@ export class ClickhouseConnection implements DatabaseConnection {
         ...compiledQuery.query.values?.values.map(v => v.values) ?? [],
       ]
 
+      
+      const schema = compiledQuery.query.into?.table?.schema?.name;
+      const table = compiledQuery.query.into?.table.identifier.name ?? "";
+      const fullQualifiedTable = schema ? `${schema}.${table}` : table
       const resultSet = await this.#client.insert({
-        table: compiledQuery.query.into.table.identifier.name,
+        table: fullQualifiedTable,
         format: 'JSONCompactEachRowWithNames',
         values,
         clickhouse_settings: {


### PR DESCRIPTION
Sorry for the dirty PR, but I wanted to make sure you were open to accepting them before cleaning it up.

This supports using a clickhouse database / kysley schema on insert tables.  Lines 47/48.

If you're interested let me know and I can cleanup the formatting issues.