### PR TITLE
Fix: insert query and session id issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@biomejs/biome": "^1.5.2",
     "@clickhouse/client": "^1.4.1",
     "@types/bluebird": "^3.5.42",
+    "@types/node": "^22.14.1",
     "kysely": "^0.27.2",
     "typescript": "^5.3.3",
     "vitest": "^1.2.1"

--- a/src/ClickhouseConnection.ts
+++ b/src/ClickhouseConnection.ts
@@ -7,7 +7,7 @@ import {
 import { createClient } from '@clickhouse/client'
 import { ClickhouseDialectConfig } from '.';
 import { NodeClickHouseClient } from '@clickhouse/client/dist/client';
-
+import { randomUUID } from 'node:crypto';
 
 export class ClickhouseConnection implements DatabaseConnection {
   #client: NodeClickHouseClient
@@ -18,7 +18,8 @@ export class ClickhouseConnection implements DatabaseConnection {
       clickhouse_settings: {
         ...config.options?.clickhouse_settings,
         date_time_input_format: 'best_effort',
-      }
+      },
+      session_id: randomUUID(),
     })
   }
 
@@ -43,41 +44,33 @@ export class ClickhouseConnection implements DatabaseConnection {
   }
 
   async executeQuery<O>(compiledQuery: CompiledQuery): Promise<QueryResult<O>> {
+    const queryKind = compiledQuery.query.kind
 
-    if (compiledQuery.query.kind === 'InsertQueryNode') {
-
-      const values = [
-        compiledQuery.query.columns?.map(c => c.column.name) ?? [],
-        // @ts-expect-error: fix types
-        ...compiledQuery.query.values?.values.map(v => v.values) ?? [],
-      ]
-
-      
-      const schema = compiledQuery.query.into?.table?.schema?.name;
-      const table = compiledQuery.query.into?.table.identifier.name ?? "";
-      const fullQualifiedTable = schema ? `${schema}.${table}` : table
-      const resultSet = await this.#client.insert({
-        table: fullQualifiedTable,
-        format: 'JSONCompactEachRowWithNames',
-        values,
-        clickhouse_settings: {
-          date_time_input_format: 'best_effort',
-        },
-      })
-
-      return {
-        rows: [],
-        numAffectedRows: BigInt(resultSet.summary?.written_rows ?? 0),
-        numChangedRows: BigInt(resultSet.summary?.written_rows ?? 0),
-      }
-    }
-
-    if (compiledQuery.query.kind === 'UpdateQueryNode' || compiledQuery.query.kind === 'SelectQueryNode') {
+    if (queryKind === 'InsertQueryNode' || queryKind === 'UpdateQueryNode' || queryKind === 'SelectQueryNode') {
       const query = this.prepareQuery(compiledQuery)
 
       const resultSet = await this.#client.query({
         query,
+        clickhouse_settings: {
+          ...(queryKind === 'InsertQueryNode' && {
+            date_time_input_format: "best_effort",
+          }),
+        },
       })
+
+      if (queryKind === 'InsertQueryNode') {
+        const summary = resultSet.response_headers["x-clickhouse-summary"]
+        const summaryObject = JSON.parse(
+          (Array.isArray(summary) ? summary[0] : summary) ?? '{}'
+        )
+
+        return {
+          rows: [],
+          numAffectedRows: BigInt(summaryObject.written_rows ?? 0),
+          numChangedRows: BigInt(summaryObject.written_rows ?? 0),
+        }
+      }
+
       const response = await resultSet.json()
 
       return {

--- a/src/ClickhouseConnection.ts
+++ b/src/ClickhouseConnection.ts
@@ -44,22 +44,19 @@ export class ClickhouseConnection implements DatabaseConnection {
   }
 
   async executeQuery<O>(compiledQuery: CompiledQuery): Promise<QueryResult<O>> {
-    const queryKind = compiledQuery.query.kind
+    if (compiledQuery.query.kind === 'InsertQueryNode') {
+      // @ts-expect-error: fix types
+      if (!compiledQuery.query.values?.values) {
+        // handle complex query (ex: INSERT INTO ... SELECT ...)
+        const query = this.prepareQuery(compiledQuery)
+        const result = await this.#client.query({
+          query,
+          clickhouse_settings: {
+            date_time_input_format: 'best_effort',
+          },
+        });
 
-    if (queryKind === 'InsertQueryNode' || queryKind === 'UpdateQueryNode' || queryKind === 'SelectQueryNode') {
-      const query = this.prepareQuery(compiledQuery)
-
-      const resultSet = await this.#client.query({
-        query,
-        clickhouse_settings: {
-          ...(queryKind === 'InsertQueryNode' && {
-            date_time_input_format: "best_effort",
-          }),
-        },
-      })
-
-      if (queryKind === 'InsertQueryNode') {
-        const summary = resultSet.response_headers["x-clickhouse-summary"]
+        const summary = result.response_headers['x-clickhouse-summary']
         const summaryObject = JSON.parse(
           (Array.isArray(summary) ? summary[0] : summary) ?? '{}'
         )
@@ -71,6 +68,37 @@ export class ClickhouseConnection implements DatabaseConnection {
         }
       }
 
+      const values = [
+        compiledQuery.query.columns?.map(c => c.column.name) ?? [],
+        // @ts-expect-error: fix types
+        ...compiledQuery.query.values?.values.map(v => v.values) ?? [],
+      ]
+      
+      const schema = compiledQuery.query.into?.table?.schema?.name;
+      const table = compiledQuery.query.into?.table.identifier.name ?? "";
+      const fullQualifiedTable = schema ? `${schema}.${table}` : table
+      const resultSet = await this.#client.insert({
+        table: fullQualifiedTable,
+        format: 'JSONCompactEachRowWithNames',
+        values,
+        clickhouse_settings: {
+          date_time_input_format: 'best_effort',
+        },
+      })
+
+      return {
+        rows: [],
+        numAffectedRows: BigInt(resultSet.summary?.written_rows ?? 0),
+        numChangedRows: BigInt(resultSet.summary?.written_rows ?? 0),
+      }
+    }
+
+    if (compiledQuery.query.kind === 'UpdateQueryNode' || compiledQuery.query.kind === 'SelectQueryNode') {
+      const query = this.prepareQuery(compiledQuery)
+
+      const resultSet = await this.#client.query({
+        query,
+      })
       const response = await resultSet.json()
 
       return {

--- a/src/ClickhouseConnection.ts
+++ b/src/ClickhouseConnection.ts
@@ -40,7 +40,10 @@ export class ClickhouseConnection implements DatabaseConnection {
       return `'${param.replace(/'/gm, `\\'`).replace(/\\"/g, '\\\\"')}'`
     })
 
-    return compiledSql
+    return compiledSql.replace(
+      /^update ((`\w+`\.)*`\w+`) set/i,
+      "alter table $1 update"
+    )
   }
 
   async executeQuery<O>(compiledQuery: CompiledQuery): Promise<QueryResult<O>> {
@@ -93,7 +96,7 @@ export class ClickhouseConnection implements DatabaseConnection {
       }
     }
 
-    if (compiledQuery.query.kind === 'UpdateQueryNode' || compiledQuery.query.kind === 'SelectQueryNode') {
+    if (compiledQuery.query.kind === 'SelectQueryNode') {
       const query = this.prepareQuery(compiledQuery)
 
       const resultSet = await this.#client.query({


### PR DESCRIPTION
Hello,

First of all, I'd like to express my deep gratitude for creating the kysely ClickHouse dialect.

While using it, I encountered some issues where it couldn't handle complex insert queries and couldn't use temporary tables, so I made some modifications to address these problems.

Additionally, with these changes, it's now possible to use temporary tables with `db.connection().execute(async (db) => { ... })`.

I hope these modifications can be helpful for users with more complex query requirements.

Best regards